### PR TITLE
xcode-scroll-bottom-bug

### DIFF
--- a/playbook/numsw-xcode.playground/Sources/playgrounds/RenderViewController2.swift
+++ b/playbook/numsw-xcode.playground/Sources/playgrounds/RenderViewController2.swift
@@ -45,6 +45,7 @@ public class RenderViewController2: UIViewController {
     
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        scrollView.frame = self.view.frame
         updateViews()
     }
     

--- a/playgrounds/RenderViewController2.swift
+++ b/playgrounds/RenderViewController2.swift
@@ -45,6 +45,7 @@ public class RenderViewController2: UIViewController {
     
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        scrollView.frame = self.view.frame
         updateViews()
     }
     


### PR DESCRIPTION
@colorbox ScrollView実装でのRenderViewControllerですが、
xcodeのplaygroundで開いたときだけ、一番下までスクロールできないバグが出ます。

iPadのplaygroundや、sandboxのアプリ上では大丈夫なのですが。

何かわかりますか？

以下の画像の赤で囲った部分が、本当は1個グラフが見えるはずなのに、
スクロールのバネが戻ってしまって見れない。

<img width="1280" alt="aaa" src="https://cloud.githubusercontent.com/assets/312792/23589910/c5353260-0219-11e7-9b37-b73d6a0e0f58.png">
