### PR TITLE
Fix: `defer` uses wrong variable in NDArrayTransformation

### DIFF
--- a/Sources/numsw/NDArray/NDArrayTransformation.swift
+++ b/Sources/numsw/NDArray/NDArrayTransformation.swift
@@ -33,7 +33,7 @@ extension NDArray {
         let outShape = axes.map { self.shape[$0] }
         
         let outPointer = UnsafeMutablePointer<T>.allocate(capacity: self.elements.count)
-        defer { outPointer.deallocate(capacity: elements.count) }
+        defer { outPointer.deallocate(capacity: self.elements.count) }
         
         let inIndices = calculateIndices(formatIndicesInAxes(shape, []))
         


### PR DESCRIPTION
Fix #58.
In `NDArrayTransformation.swift`, `defer` uses the variable `elements` which is defined later.
This causes compile error in XCode8.3, or Swift Playgrounds.
Use `self.elements` instead (It only uses elements count, and these two `elements` have same number of elements).