### PR TITLE
Fix PlaygroundRunner error in some environment

### DIFF
--- a/Tools/lib/PlaygroundRunner.rb
+++ b/Tools/lib/PlaygroundRunner.rb
@@ -32,6 +32,7 @@ class PlaygroundRunner
 
       Dir.chdir(temp_dir) do
         exec([
+          "xcrun",
           "swiftc", "-v",
           "main.swift",
           "lib_bundle.swift",


### PR DESCRIPTION
```
exec: [swiftc -v main.swift lib_bundle.swift -o exe]
Apple Swift version 3.1 (swiftlang-802.0.51 clang-802.0.41)
Target: x86_64-apple-macosx10.9
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c -primary-file main.swift lib_bundle.swift -target x86_64-apple-macosx10.9 -enable-objc-interop -color-diagnostics -module-name exe -o /var/folders/fv/jz0_mngn575738sb6chqh77c0000gn/T/main-a14949.o
<unknown>:0: error: cannot load underlying module for 'CoreGraphics'
<unknown>:0: note: did you forget to set an SDK using -sdk or SDKROOT?
<unknown>:0: note: use "xcrun swiftc" to select the default macOS SDK installed with Xcode
```

私の環境(Swiftenvが入っていると?)動かなかったので、修正しました。
