### PR TITLE
Refactor `Matrix#inverted`

### DIFF
--- a/Sources/numsw/Matrix/MatrixInvert.swift
+++ b/Sources/numsw/Matrix/MatrixInvert.swift
@@ -17,28 +17,24 @@ enum InvertError: Error {
             var workspace: [Double]      = [Double](repeating: 0.0, count: Int(N))
             var error: __CLPK_integer   = 0
             
-            var N1 = N
-            var N2 = N
-            
-            // LU decomposition
-            dgetrf_(&N, &N1, &inMatrix, &N2, &pivots, &error)
-            if error < 0 {
-                throw InvertError.IrregalValue(argument: -Int(error))
-            } else if error > 0 {
-                throw InvertError.SingularMatrix
+            try withUnsafeMutablePointer(to: &N) { N in
+                // LU decomposition
+                dgetrf_(N, N, &inMatrix, N, &pivots, &error)
+                if error < 0 {
+                    throw InvertError.IrregalValue(argument: -Int(error))
+                } else if error > 0 {
+                    throw InvertError.SingularMatrix
+                }
+                
+                // solve
+                dgetri_(N, &inMatrix, N, &pivots, &workspace, N, &error)
+                if error < 0 {
+                    throw InvertError.IrregalValue(argument: -Int(error))
+                } else if error > 0 {
+                    throw InvertError.SingularMatrix
+                }
             }
             
-            N1 = N
-            N2 = N
-            
-            // solve
-            dgetri_(&N, &inMatrix, &N1, &pivots, &workspace, &N2, &error)
-            if error < 0 {
-                throw InvertError.IrregalValue(argument: -Int(error))
-            } else if error > 0 {
-                throw InvertError.SingularMatrix
-            }
-
             return Matrix<Double>(rows: rows,
                                   columns: columns,
                                   elements: inMatrix)
@@ -56,26 +52,22 @@ enum InvertError: Error {
             var workspace: [Float]      = [Float](repeating: 0.0, count: Int(N))
             var error: __CLPK_integer   = 0
             
-            var N1 = N
-            var N2 = N
-            
-            // LU decomposition
-            sgetrf_(&N, &N1, &inMatrix, &N2, &pivots, &error)
-            if error < 0 {
-                throw InvertError.IrregalValue(argument: -Int(error))
-            } else if error > 0 {
-                throw InvertError.SingularMatrix
-            }
-            
-            N1 = N
-            N2 = N
-            
-            // solve
-            sgetri_(&N, &inMatrix, &N1, &pivots, &workspace, &N2, &error)
-            if error < 0 {
-                throw InvertError.IrregalValue(argument: -Int(error))
-            } else if error > 0 {
-                throw InvertError.SingularMatrix
+            try withUnsafeMutablePointer(to: &N) { N in
+                // LU decomposition
+                sgetrf_(N, N, &inMatrix, N, &pivots, &error)
+                if error < 0 {
+                    throw InvertError.IrregalValue(argument: -Int(error))
+                } else if error > 0 {
+                    throw InvertError.SingularMatrix
+                }
+                
+                // solve
+                sgetri_(N, &inMatrix, N, &pivots, &workspace, N, &error)
+                if error < 0 {
+                    throw InvertError.IrregalValue(argument: -Int(error))
+                } else if error > 0 {
+                    throw InvertError.SingularMatrix
+                }
             }
             
             return Matrix<Float>(rows: rows,


### PR DESCRIPTION
変数を分散しているところを一本化。
`sgetrf`, `sgetri`は`N`を`UnsafeMutablePointer`で取るが変更はされない。